### PR TITLE
Add PhotonVision

### DIFF
--- a/src/main/deploy/pathplanner/autos/Alliance Cage Taxi.auto
+++ b/src/main/deploy/pathplanner/autos/Alliance Cage Taxi.auto
@@ -13,7 +13,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/Anchor Taxi.auto
+++ b/src/main/deploy/pathplanner/autos/Anchor Taxi.auto
@@ -13,7 +13,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/Opponent Cage Taxi.auto
+++ b/src/main/deploy/pathplanner/autos/Opponent Cage Taxi.auto
@@ -13,7 +13,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/Test Alliance L4 Station.auto
+++ b/src/main/deploy/pathplanner/autos/Test Alliance L4 Station.auto
@@ -67,7 +67,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/Test Alliance L4.auto
+++ b/src/main/deploy/pathplanner/autos/Test Alliance L4.auto
@@ -37,7 +37,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/Test Anchor L4 Algae.auto
+++ b/src/main/deploy/pathplanner/autos/Test Anchor L4 Algae.auto
@@ -79,7 +79,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/Test Anchor L4.auto
+++ b/src/main/deploy/pathplanner/autos/Test Anchor L4.auto
@@ -55,7 +55,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/Test Opponent L4 Station.auto
+++ b/src/main/deploy/pathplanner/autos/Test Opponent L4 Station.auto
@@ -67,7 +67,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/Test Opponent L4.auto
+++ b/src/main/deploy/pathplanner/autos/Test Opponent L4.auto
@@ -55,7 +55,7 @@
       ]
     }
   },
-  "resetOdom": true,
+  "resetOdom": false,
   "folder": null,
   "choreoAuto": false
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -41,8 +41,8 @@ public final class Constants {
 
   public final class QuestConstants {
     public static final Transform2d ROBOT_TO_QUEST = new Transform2d(
-        Inches.of(9).unaryMinus(), // positive forward from robot center
-        Inches.of(9), // positive left of robot center
+        Inches.of(-11.375), // x, positive forward from robot center
+        Inches.of(9), // y, positive left of robot center
         Rotation2d.k180deg); // rotation around the robot center
     public static final Matrix<N3, N1> QUESTNAV_STD_DEVS = VecBuilder.fill(
         0.02, // Trust down to 2cm in X direction
@@ -58,8 +58,8 @@ public final class Constants {
         .loadField(AprilTagFields.k2025ReefscapeWelded);
     public static final Transform3d ROBOT_TO_CAMERA = new Transform3d(
         Inches.of(5), // x, positive forward
-        Inches.of(11), // y, positive left
-        Inches.of(19.5), // z, positive up
+        Inches.of(10), // y, positive left
+        Inches.of(18.75), // z, positive up
         new Rotation3d(
             Degrees.of(0), // roll, counterclockwise rotation angle around the X axis
             Degrees.of(-15), // pitch, counterclockwise rotation angle around the y axis

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -2,11 +2,15 @@ package frc.robot;
 
 import static edu.wpi.first.units.Units.*;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
@@ -45,6 +49,28 @@ public final class Constants {
         0.02, // Trust down to 2cm in Y direction
         0.035 // Trust down to 2 degrees rotational
     );
+  }
+
+  public static class PVConstants {
+    public static final String CAMERA_NAME = "Yellow Camera";
+    // The layout of the AprilTags on the field
+    public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout
+        .loadField(AprilTagFields.k2025ReefscapeWelded);
+    public static final Transform3d ROBOT_TO_CAMERA = new Transform3d(
+        Inches.of(5), // x, positive forward
+        Inches.of(11), // y, positive left
+        Inches.of(19.5), // z, positive up
+        new Rotation3d(
+            Degrees.of(0), // roll, counterclockwise rotation angle around the X axis
+            Degrees.of(-15), // pitch, counterclockwise rotation angle around the y axis
+            Degrees.of(0) // yaw, counterclockwise rotation angle around the z axis
+        ));
+
+    // The standard deviations of our vision estimated poses, which affect
+    // correction rate
+    // (Fake values. Experiment and determine estimation noise on an actual robot.)
+    public static final Matrix<N3, N1> kSingleTagStdDevs = VecBuilder.fill(4, 4, 8);
+    public static final Matrix<N3, N1> kMultiTagStdDevs = VecBuilder.fill(0.5, 0.5, 1);
   }
 
   public static class OperatorConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -34,9 +34,9 @@ public final class Constants {
     };
 
     public static final Translation2d reefPositionWS = new Translation2d(4.489, 4.0259);
-    public static final Pose2d REEF_LEFT = new Pose2d(3.19, 4.286, Rotation2d.kZero);
-    public static final Pose2d REEF_CENTER = new Pose2d(3.19, 4.030, Rotation2d.kZero);
-    public static final Pose2d REEF_RIGHT = new Pose2d(3.19, 3.948, Rotation2d.kZero);
+    public static final Pose2d REEF_LEFT = new Pose2d(3.292, 4.201, Rotation2d.kZero);
+    public static final Pose2d REEF_CENTER = new Pose2d(3.292, 4.000, Rotation2d.kZero);
+    public static final Pose2d REEF_RIGHT = new Pose2d(3.292, 3.840, Rotation2d.kZero);
   }
 
   public final class QuestConstants {
@@ -58,11 +58,11 @@ public final class Constants {
         .loadField(AprilTagFields.k2025ReefscapeWelded);
     public static final Transform3d ROBOT_TO_CAMERA = new Transform3d(
         Inches.of(5), // x, positive forward
-        Inches.of(10), // y, positive left
-        Inches.of(18.75), // z, positive up
+        Inches.of(12.4), // y, positive left
+        Inches.of(21.75), // z, positive up
         new Rotation3d(
             Degrees.of(0), // roll, counterclockwise rotation angle around the X axis
-            Degrees.of(-15), // pitch, counterclockwise rotation angle around the y axis
+            Degrees.of(0), // pitch, counterclockwise rotation angle around the y axis
             Degrees.of(0) // yaw, counterclockwise rotation angle around the z axis
         ));
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -41,8 +41,8 @@ public final class Constants {
 
   public final class QuestConstants {
     public static final Transform2d ROBOT_TO_QUEST = new Transform2d(
-        Inches.of(-11.375), // x, positive forward from robot center
-        Inches.of(9), // y, positive left of robot center
+        Meters.of(-0.222), // x, positive forward from robot center 8.74 in
+        Meters.of(0.162), // y, positive left of robot center 5.944 in
         Rotation2d.k180deg); // rotation around the robot center
     public static final Matrix<N3, N1> QUESTNAV_STD_DEVS = VecBuilder.fill(
         0.02, // Trust down to 2cm in X direction
@@ -76,7 +76,7 @@ public final class Constants {
   public static class OperatorConstants {
     public static final int kDriverControllerPort = 0;
     public static final int kOperatorControllerPort = 1;
-    public static final double DEADBAND = 0.08;
+    public static final double DEADBAND = 0.01;
   }
 
   public static class ElevatorConstants {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -160,7 +160,7 @@ public class RobotContainer {
 
 		m_driverController.leftBumper()
 				.whileTrue(autoDriving(new AutoDriveToReefCommand(ReefConstants.REEF_LEFT, drivebase)));
-		m_driverController.leftBumper().and(m_driverController.rightBumper())
+		m_driverController.y()
 				.whileTrue(autoDriving(new AutoDriveToReefCommand(ReefConstants.REEF_CENTER, drivebase)));
 		m_driverController.rightBumper()
 				.whileTrue(autoDriving(new AutoDriveToReefCommand(ReefConstants.REEF_RIGHT, drivebase)));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -53,7 +53,7 @@ public class RobotContainer {
 
 		// reset the odometry to the pv's inital position
 		new Trigger(RobotState::isEnabled)
-				.onTrue(Commands.runOnce(() -> resetOdometry(photonVision.getPose())));
+				.onTrue(autoDriving(Commands.runOnce(() -> resetOdometry(photonVision.getPose()))));
 
 		// Configure commands for PathPlanner.
 		// Autons created in PathPlanner must not reset the position of the robot

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,21 +20,28 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.RobotState;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 public class RobotContainer {
 	private final SendableChooser<Command> autoChooser;
-	private QuestNavSubsystem questNav = new QuestNavSubsystem();
-	public final SwerveSubsystem drivebase = new SwerveSubsystem(questNav::setQuestPose, questNav::getVisionData);
-	private Elevator m_Elevator = new Elevator();
-	private Coral m_Coral = new Coral();
-	private Algae m_Algae = new Algae();
+
+	private final SwerveSubsystem drivebase = new SwerveSubsystem();
+	private final QuestNavSubsystem questNav = new QuestNavSubsystem(drivebase::addVisionMeasurement);
+	private final PhotonVisionSubsystem photonVision = new PhotonVisionSubsystem(
+			drivebase::addVisionMeasurement);
+
+	private final Elevator elevator = new Elevator();
+	private final Coral coral = new Coral();
+	private final Algae algae = new Algae();
 	// private Climb m_Climb = new Climb();
+
 	public final CommandXboxController m_driverController = new CommandXboxController(
 			OperatorConstants.kDriverControllerPort);
 	public final CommandXboxController m_operatorController = new CommandXboxController(
@@ -44,16 +51,25 @@ public class RobotContainer {
 	private boolean autoDriving = false;
 
 	public RobotContainer() {
+		drivebase.setResetVision(questNav::setQuestPose);
+		drivebase.resetOdometry(new Pose2d(1, 1, Rotation2d.kZero));
+
+		// reset the odometry to the pv's inital position
+		// TODO: need to change the autons in pathplanner to not reset the odometry at
+		// the start
+		new Trigger(RobotState::isEnabled)
+				.onTrue(Commands.runOnce(() -> drivebase.resetOdometry(photonVision.getPose())));
+
 		calibrateQuestCommand = new CalibrateQuestCommand();
 		NamedCommands.registerCommand("L2Config", moveTo(ReefConstants.Level.L2));
 		NamedCommands.registerCommand("L3Config", moveTo(ReefConstants.Level.L3));
 		NamedCommands.registerCommand("L4Config", moveTo(ReefConstants.Level.L4));
 		NamedCommands.registerCommand("A1Config", moveTo(ReefConstants.Level.A1));
 		NamedCommands.registerCommand("CSConfig", moveTo(ReefConstants.Level.CS));
-		NamedCommands.registerCommand("IntakeCoral", m_Coral.intakeCoralCommand());
-		NamedCommands.registerCommand("EjectCoral", m_Coral.ejectCoralCommand());
-		NamedCommands.registerCommand("IntakeAlgae", m_Coral.intakeCoralCommand());
-		NamedCommands.registerCommand("EjectAlgae", m_Coral.ejectCoralCommand());
+		NamedCommands.registerCommand("IntakeCoral", coral.intakeCoralCommand());
+		NamedCommands.registerCommand("EjectCoral", coral.ejectCoralCommand());
+		NamedCommands.registerCommand("IntakeAlgae", coral.intakeCoralCommand());
+		NamedCommands.registerCommand("EjectAlgae", coral.ejectCoralCommand());
 
 		setMotorBrake(false);
 		drivebase.setDefaultCommand(driveFieldOrientedAngularVelocity);
@@ -62,8 +78,8 @@ public class RobotContainer {
 		autoChooser.setDefaultOption("None", null);
 		configureBindings();
 
-		m_Coral.getCoralDetected().onTrue(rumbleControllers(0.8, 0.5));
-		m_Algae.getAlgaeDetected().onTrue(rumbleControllers(0.8, 0.5));
+		coral.getCoralDetected().onTrue(rumbleControllers(0.8, 0.5));
+		algae.getAlgaeDetected().onTrue(rumbleControllers(0.8, 0.5));
 	}
 
 	/**
@@ -109,19 +125,19 @@ public class RobotContainer {
 
 		// intake coral
 		m_operatorController.leftBumper()
-				.whileTrue(m_Coral.intakeCoralCommand()
-						.andThen(m_Coral.moveCoralCommand(CoralConstants.STOWED)));
+				.whileTrue(coral.intakeCoralCommand()
+						.andThen(coral.moveCoralCommand(CoralConstants.STOWED)));
 		// eject coral
 		m_operatorController.rightBumper()
-				.onTrue(m_Coral.ejectCoralCommand()
-						.andThen(m_Coral.moveCoralCommand(CoralConstants.STOWED)));
-		m_operatorController.back().onTrue(m_Coral.ejectCoralSlowCommand());
+				.onTrue(coral.ejectCoralCommand()
+						.andThen(coral.moveCoralCommand(CoralConstants.STOWED)));
+		m_operatorController.back().onTrue(coral.ejectCoralSlowCommand());
 		// intake algae
 		m_operatorController.leftTrigger()
-				.whileTrue(m_Algae.intakeAlgaeCommand()
-						.andThen(m_Algae.moveAlgaeCommand(Degrees.of(50.0))));
+				.whileTrue(algae.intakeAlgaeCommand()
+						.andThen(algae.moveAlgaeCommand(Degrees.of(50.0))));
 		// eject algae
-		m_operatorController.rightTrigger().onTrue(m_Algae.ejectAlgaeCommand());
+		m_operatorController.rightTrigger().onTrue(algae.ejectAlgaeCommand());
 
 		// m_driverController.leftBumper().whileTrue(drivebase.getAngleCharacterizationCommand());
 		// m_driverController.rightBumper().whileTrue(drivebase.getDriveCharacterizationCommand());
@@ -184,17 +200,17 @@ public class RobotContainer {
 					|| level == ReefConstants.Level.L3 || level == ReefConstants.Level.L4) {
 				return Commands
 						.parallel(
-								m_Elevator.moveElevatorCommand(elevatorHeight),
-								m_Algae.moveAlgaeCommand(algaeAngle))
-						.andThen(m_Coral.moveCoralCommand(coralAngle))
-						.andThen(m_Coral.ejectCoralCommand())
+								elevator.moveElevatorCommand(elevatorHeight),
+								algae.moveAlgaeCommand(algaeAngle))
+						.andThen(coral.moveCoralCommand(coralAngle))
+						.andThen(coral.ejectCoralCommand())
 						.andThen(moveTo(ReefConstants.Level.CS));
 			} else {
 				// all the other positions just move all three subsystems at the same time
 				return Commands.parallel(
-						m_Elevator.moveElevatorCommand(elevatorHeight),
-						m_Algae.moveAlgaeCommand(algaeAngle),
-						m_Coral.moveCoralCommand(coralAngle))
+						elevator.moveElevatorCommand(elevatorHeight),
+						algae.moveAlgaeCommand(algaeAngle),
+						coral.moveCoralCommand(coralAngle))
 						.andThen(rumbleControllers(0.2, 0.2));
 			}
 		} catch (Exception e) {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,6 +7,7 @@ import frc.robot.Constants.ElevatorConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.AutoDriveToReefCommand;
 import frc.robot.subsystems.*;
+import frc.robot.util.CalibrateQuestCommand;
 import swervelib.SwerveInputStream;
 
 import static edu.wpi.first.units.Units.Degrees;
@@ -153,6 +154,9 @@ public class RobotContainer {
 		// m_driverController.a()
 		// .whileTrue(
 		// autoDriving(drivebase.getPathFindingCommand()));
+
+		m_driverController.b().whileTrue(autoDriving(
+				new CalibrateQuestCommand().determineOffsetToRobotCenter(drivebase, questNav)));
 
 		m_driverController.leftBumper()
 				.whileTrue(autoDriving(new AutoDriveToReefCommand(ReefConstants.REEF_LEFT, drivebase)));

--- a/src/main/java/frc/robot/commands/AutoDriveToReefCommand.java
+++ b/src/main/java/frc/robot/commands/AutoDriveToReefCommand.java
@@ -61,7 +61,7 @@ public class AutoDriveToReefCommand extends Command {
 
       // this will infinitly consume the drivetrain, but this command ends once the
       // user releases the trigger (needed for alert to function)
-      followingCommand = Commands.waitUntil(() -> false).finallyDo(() -> tooCloseAlert.set(false));
+      followingCommand = Commands.idle().finallyDo(() -> tooCloseAlert.set(false));
     } else {
       swerveSubsystem.getSwerveDrive().field.getObject("Goal").setPose(dest);
 

--- a/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
@@ -1,0 +1,142 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonPoseEstimator;
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+import org.photonvision.targeting.PhotonTrackedTarget;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.StructPublisher;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.PVConstants;
+import frc.robot.util.VisionData.EstimateConsumer;
+
+public class PhotonVisionSubsystem extends SubsystemBase {
+  private final PhotonCamera camera;
+  private final PhotonPoseEstimator photonEstimator;
+  private final EstimateConsumer estConsumer;
+  private final StructPublisher<Pose2d> publisher = NetworkTableInstance.getDefault()
+      .getStructTopic("photonvision/WorldPose", Pose2d.struct).publish();
+
+  private Matrix<N3, N1> curStdDevs;
+  private Pose2d lastUpdatedPose;
+
+  /** Creates a new PhotonVisionSubsystem. */
+  public PhotonVisionSubsystem(EstimateConsumer estConsumer) {
+    this.estConsumer = estConsumer;
+    camera = new PhotonCamera(PVConstants.CAMERA_NAME);
+
+    photonEstimator = new PhotonPoseEstimator(PVConstants.kTagLayout,
+        PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, PVConstants.ROBOT_TO_CAMERA);
+    photonEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
+
+    lastUpdatedPose = new Pose2d(1, 1, Rotation2d.kZero);
+  }
+
+  /**
+   * Calculates new standard deviations This algorithm is a heuristic that creates
+   * dynamic standard
+   * deviations based on number of tags, estimation strategy, and distance from
+   * the tags.
+   *
+   * @param estimatedPose The estimated pose to guess standard deviations for.
+   * @param targets       All targets in this camera frame
+   */
+  private void updateEstimationStdDevs(
+      Optional<EstimatedRobotPose> estimatedPose, List<PhotonTrackedTarget> targets) {
+    if (estimatedPose.isEmpty()) {
+      // No pose input. Default to single-tag std devs
+      curStdDevs = PVConstants.kSingleTagStdDevs;
+
+    } else {
+      // Pose present. Start running Heuristic
+      var estStdDevs = PVConstants.kSingleTagStdDevs;
+      int numTags = 0;
+      double avgDist = 0;
+
+      // Precalculation - see how many tags we found, and calculate an
+      // average-distance metric
+      for (var tgt : targets) {
+        var tagPose = photonEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
+        if (tagPose.isEmpty())
+          continue;
+        numTags++;
+        avgDist += tagPose
+            .get()
+            .toPose2d()
+            .getTranslation()
+            .getDistance(estimatedPose.get().estimatedPose.toPose2d().getTranslation());
+      }
+
+      if (numTags == 0) {
+        // No tags visible. Default to single-tag std devs
+        curStdDevs = PVConstants.kSingleTagStdDevs;
+      } else {
+        // One or more tags visible, run the full heuristic.
+        avgDist /= numTags;
+        // Decrease std devs if multiple targets are visible
+        if (numTags > 1)
+          estStdDevs = PVConstants.kMultiTagStdDevs;
+        // Increase std devs based on (average) distance
+        if (numTags == 1 && avgDist > 4)
+          estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+        else
+          estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
+        curStdDevs = estStdDevs;
+      }
+    }
+  }
+
+  public Pose2d getPose() {
+    return lastUpdatedPose;
+  }
+
+  /**
+   * Returns the latest standard deviations of the estimated pose from {@link
+   * #getEstimatedGlobalPose()}, for use with {@link
+   * edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
+   * SwerveDrivePoseEstimator}. This should
+   * only be used when there are targets visible.
+   */
+  public Matrix<N3, N1> getEstimationStdDevs() {
+    return curStdDevs;
+  }
+
+  // This method will be called once per scheduler run
+  @Override
+  public void periodic() {
+    Optional<EstimatedRobotPose> visionEst = Optional.empty();
+    for (var change : camera.getAllUnreadResults()) {
+      visionEst = photonEstimator.update(change);
+      updateEstimationStdDevs(visionEst, change.getTargets());
+
+      visionEst.ifPresent(
+          est -> {
+            // Change our trust in the measurement based on the tags we can see
+            // var estStdDevs = getEstimationStdDevs();
+
+            publisher.accept(est.estimatedPose.toPose2d());
+            // commented out the acceptor because we are relying on the questnav only once
+            // the inital position has been set
+            // could use further testing
+            // estConsumer.accept(est.estimatedPose.toPose2d(), est.timestampSeconds,
+            // estStdDevs);
+            lastUpdatedPose = est.estimatedPose.toPose2d();
+          });
+    }
+  }
+}

--- a/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
@@ -15,128 +15,167 @@ import org.photonvision.targeting.PhotonTrackedTarget;
 
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StructPublisher;
+import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.PVConstants;
 import frc.robot.util.VisionData.EstimateConsumer;
 
 public class PhotonVisionSubsystem extends SubsystemBase {
-  private final PhotonCamera camera;
-  private final PhotonPoseEstimator photonEstimator;
-  private final EstimateConsumer estConsumer;
-  private final StructPublisher<Pose2d> publisher = NetworkTableInstance.getDefault()
-      .getStructTopic("photonvision/WorldPose", Pose2d.struct).publish();
+	private final PhotonCamera camera;
+	private final PhotonPoseEstimator photonEstimator;
+	private final EstimateConsumer estConsumer;
+	private final boolean useEstConsumer;
+	private final LinearFilter xFilter;
+	private final LinearFilter yFilter;
+	private final LinearFilter thetaFilter;
+	private final Alert cameraDisconnectedAlert;
+	private final StructPublisher<Pose2d> publisherRaw = NetworkTableInstance.getDefault()
+			.getStructTopic("photonvision/WorldPoseRaw", Pose2d.struct).publish();
+	private final StructPublisher<Pose2d> publisherFiltered = NetworkTableInstance.getDefault()
+			.getStructTopic("photonvision/WorldPoseFiltered", Pose2d.struct).publish();
 
-  private Matrix<N3, N1> curStdDevs;
-  private Pose2d lastUpdatedPose;
+	private Matrix<N3, N1> curStdDevs;
+	private Pose2d lastUpdatedPose;
 
-  /** Creates a new PhotonVisionSubsystem. */
-  public PhotonVisionSubsystem(EstimateConsumer estConsumer) {
-    this.estConsumer = estConsumer;
-    camera = new PhotonCamera(PVConstants.CAMERA_NAME);
+	/**
+	 * Creates a new PhotonVisionSubsystem.
+	 * 
+	 * @param estConsumer    consumer to add the vision data to
+	 * @param useEstConsumer whether to use the estimation consumer. Set to
+	 *                       {@code false} if using QuestNav. Set to {@code true} to
+	 *                       continually update the robot's pose with PV
+	 *                       calculations.
+	 */
+	public PhotonVisionSubsystem(EstimateConsumer estConsumer, boolean useEstConsumer) {
+		this.estConsumer = estConsumer;
+		this.useEstConsumer = useEstConsumer;
+		camera = new PhotonCamera(PVConstants.CAMERA_NAME);
+		cameraDisconnectedAlert = new Alert("PhotonVision Not Connected!!", AlertType.kError);
 
-    photonEstimator = new PhotonPoseEstimator(PVConstants.kTagLayout,
-        PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, PVConstants.ROBOT_TO_CAMERA);
-    photonEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
+		// We will filter the position data because we do not care about the phase delay
+		// added (the robot will be stationary when the position is used).
+		// Also filtering because we could accidentally set out position to a bad data
+		// position if we are just grabbing the raw position data.
+		xFilter = LinearFilter.singlePoleIIR(0.1, 0.02);
+		yFilter = LinearFilter.singlePoleIIR(0.1, 0.02);
+		thetaFilter = LinearFilter.singlePoleIIR(0.1, 0.02);
 
-    lastUpdatedPose = new Pose2d(1, 1, Rotation2d.kZero);
-  }
+		photonEstimator = new PhotonPoseEstimator(PVConstants.kTagLayout,
+				PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, PVConstants.ROBOT_TO_CAMERA);
+		photonEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
 
-  /**
-   * Calculates new standard deviations This algorithm is a heuristic that creates
-   * dynamic standard
-   * deviations based on number of tags, estimation strategy, and distance from
-   * the tags.
-   *
-   * @param estimatedPose The estimated pose to guess standard deviations for.
-   * @param targets       All targets in this camera frame
-   */
-  private void updateEstimationStdDevs(
-      Optional<EstimatedRobotPose> estimatedPose, List<PhotonTrackedTarget> targets) {
-    if (estimatedPose.isEmpty()) {
-      // No pose input. Default to single-tag std devs
-      curStdDevs = PVConstants.kSingleTagStdDevs;
+		lastUpdatedPose = new Pose2d(1, 1, Rotation2d.kZero);
+	}
 
-    } else {
-      // Pose present. Start running Heuristic
-      var estStdDevs = PVConstants.kSingleTagStdDevs;
-      int numTags = 0;
-      double avgDist = 0;
+	/**
+	 * Calculates new standard deviations This algorithm is a heuristic that creates
+	 * dynamic standard
+	 * deviations based on number of tags, estimation strategy, and distance from
+	 * the tags.
+	 *
+	 * @param estimatedPose The estimated pose to guess standard deviations for.
+	 * @param targets       All targets in this camera frame
+	 */
+	private void updateEstimationStdDevs(Optional<EstimatedRobotPose> estimatedPose,
+			List<PhotonTrackedTarget> targets) {
+		if (estimatedPose.isEmpty()) {
+			// No pose input. Default to single-tag std devs
+			curStdDevs = PVConstants.kSingleTagStdDevs;
+		} else {
+			// Pose present. Start running Heuristic
+			var estStdDevs = PVConstants.kSingleTagStdDevs;
+			int numTags = 0;
+			double avgDist = 0;
 
-      // Precalculation - see how many tags we found, and calculate an
-      // average-distance metric
-      for (var tgt : targets) {
-        var tagPose = photonEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
-        if (tagPose.isEmpty())
-          continue;
-        numTags++;
-        avgDist += tagPose
-            .get()
-            .toPose2d()
-            .getTranslation()
-            .getDistance(estimatedPose.get().estimatedPose.toPose2d().getTranslation());
-      }
+			// Precalculation - see how many tags we found, and calculate an
+			// average-distance metric
+			for (var tgt : targets) {
+				var tagPose = photonEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
+				if (tagPose.isEmpty())
+					continue;
+				numTags++;
+				avgDist += tagPose
+						.get()
+						.toPose2d()
+						.getTranslation()
+						.getDistance(estimatedPose.get().estimatedPose.toPose2d().getTranslation());
+			}
 
-      if (numTags == 0) {
-        // No tags visible. Default to single-tag std devs
-        curStdDevs = PVConstants.kSingleTagStdDevs;
-      } else {
-        // One or more tags visible, run the full heuristic.
-        avgDist /= numTags;
-        // Decrease std devs if multiple targets are visible
-        if (numTags > 1)
-          estStdDevs = PVConstants.kMultiTagStdDevs;
-        // Increase std devs based on (average) distance
-        if (numTags == 1 && avgDist > 4)
-          estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-        else
-          estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
-        curStdDevs = estStdDevs;
-      }
-    }
-  }
+			if (numTags == 0) {
+				// No tags visible. Default to single-tag std devs
+				curStdDevs = PVConstants.kSingleTagStdDevs;
+			} else {
+				// One or more tags visible, run the full heuristic.
+				avgDist /= numTags;
+				// Decrease std devs if multiple targets are visible
+				if (numTags > 1)
+					estStdDevs = PVConstants.kMultiTagStdDevs;
+				// Increase std devs based on (average) distance
+				if (numTags == 1 && avgDist > 4)
+					estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+				else
+					estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
+				curStdDevs = estStdDevs;
+			}
+		}
+	}
 
-  public Pose2d getPose() {
-    return lastUpdatedPose;
-  }
+	/**
+	 * Returns the past calculated world position of the robot. This value is
+	 * filtered.
+	 * 
+	 * @return the worldspace position of the robot.
+	 */
+	public Pose2d getPose() {
+		return lastUpdatedPose;
+	}
 
-  /**
-   * Returns the latest standard deviations of the estimated pose from {@link
-   * #getEstimatedGlobalPose()}, for use with {@link
-   * edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
-   * SwerveDrivePoseEstimator}. This should
-   * only be used when there are targets visible.
-   */
-  public Matrix<N3, N1> getEstimationStdDevs() {
-    return curStdDevs;
-  }
+	/**
+	 * Returns the latest standard deviations of the estimated pose from {@link
+	 * #getEstimatedGlobalPose()}, for use with {@link
+	 * edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
+	 * SwerveDrivePoseEstimator}. This should
+	 * only be used when there are targets visible.
+	 */
+	public Matrix<N3, N1> getEstimationStdDevs() {
+		return curStdDevs;
+	}
 
-  // This method will be called once per scheduler run
-  @Override
-  public void periodic() {
-    Optional<EstimatedRobotPose> visionEst = Optional.empty();
-    for (var change : camera.getAllUnreadResults()) {
-      visionEst = photonEstimator.update(change);
-      updateEstimationStdDevs(visionEst, change.getTargets());
+	// This method will be called once per scheduler run
+	@Override
+	public void periodic() {
+		cameraDisconnectedAlert.set(!camera.isConnected());
 
-      visionEst.ifPresent(
-          est -> {
-            // Change our trust in the measurement based on the tags we can see
-            // var estStdDevs = getEstimationStdDevs();
+		Optional<EstimatedRobotPose> visionEst = Optional.empty();
+		for (var change : camera.getAllUnreadResults()) {
+			visionEst = photonEstimator.update(change);
+			updateEstimationStdDevs(visionEst, change.getTargets());
 
-            publisher.accept(est.estimatedPose.toPose2d());
-            // commented out the acceptor because we are relying on the questnav only once
-            // the inital position has been set
-            // could use further testing
-            // estConsumer.accept(est.estimatedPose.toPose2d(), est.timestampSeconds,
-            // estStdDevs);
-            lastUpdatedPose = est.estimatedPose.toPose2d();
-          });
-    }
-  }
+			visionEst.ifPresent(
+					est -> {
+						Pose2d pose = est.estimatedPose.toPose2d();
+						publisherRaw.accept(pose);
+						if (useEstConsumer) {
+							// Change our trust in the measurement based on the tags we can see
+							var estStdDevs = getEstimationStdDevs();
+							estConsumer.accept(pose, est.timestampSeconds,
+									estStdDevs);
+						}
+						lastUpdatedPose = new Pose2d(
+								xFilter.calculate(pose.getX()),
+								yFilter.calculate(pose.getY()),
+								Rotation2d.fromRadians(thetaFilter.calculate(pose.getRotation().getRadians())));
+
+						publisherFiltered.accept(lastUpdatedPose);
+					});
+		}
+	}
 }

--- a/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
@@ -157,7 +157,9 @@ public class PhotonVisionSubsystem extends SubsystemBase {
 		Optional<EstimatedRobotPose> visionEst = Optional.empty();
 		for (var change : camera.getAllUnreadResults()) {
 			visionEst = photonEstimator.update(change);
-			updateEstimationStdDevs(visionEst, change.getTargets());
+			if (useEstConsumer) {
+				updateEstimationStdDevs(visionEst, change.getTargets());
+			}
 
 			visionEst.ifPresent(
 					est -> {

--- a/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
@@ -15,7 +15,7 @@ import org.photonvision.targeting.PhotonTrackedTarget;
 
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
-import edu.wpi.first.math.filter.LinearFilter;
+import edu.wpi.first.math.filter.MedianFilter;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.numbers.N1;
@@ -33,9 +33,9 @@ public class PhotonVisionSubsystem extends SubsystemBase {
 	private final PhotonPoseEstimator photonEstimator;
 	private final EstimateConsumer estConsumer;
 	private final boolean useEstConsumer;
-	private final LinearFilter xFilter;
-	private final LinearFilter yFilter;
-	private final LinearFilter thetaFilter;
+	private final MedianFilter xFilter;
+	private final MedianFilter yFilter;
+	private final MedianFilter thetaFilter;
 	private final Alert cameraDisconnectedAlert;
 	private final StructPublisher<Pose2d> publisherRaw = NetworkTableInstance.getDefault()
 			.getStructTopic("photonvision/WorldPoseRaw", Pose2d.struct).publish();
@@ -64,9 +64,9 @@ public class PhotonVisionSubsystem extends SubsystemBase {
 		// added (the robot will be stationary when the position is used).
 		// Also filtering because we could accidentally set out position to a bad data
 		// position if we are just grabbing the raw position data.
-		xFilter = LinearFilter.singlePoleIIR(0.1, 0.02);
-		yFilter = LinearFilter.singlePoleIIR(0.1, 0.02);
-		thetaFilter = LinearFilter.singlePoleIIR(0.1, 0.02);
+		xFilter = new MedianFilter(10);
+		yFilter = new MedianFilter(10);
+		thetaFilter = new MedianFilter(10);
 
 		photonEstimator = new PhotonPoseEstimator(PVConstants.kTagLayout,
 				PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, PVConstants.ROBOT_TO_CAMERA);

--- a/src/main/java/frc/robot/util/CalibrateQuestCommand.java
+++ b/src/main/java/frc/robot/util/CalibrateQuestCommand.java
@@ -43,10 +43,8 @@ public class CalibrateQuestCommand {
 	 * is non-zero, you may have to swap the x/y and their signs.
 	 */
 	public Command determineOffsetToRobotCenter(SwerveSubsystem swerveDrive, QuestNavSubsystem quest) {
-		// First reset our pose to 0, 0
-		// quest.setQuestPoseRaw(Pose2d.kZero);
-		initPose = quest.getQuestPoseRaw();
 		Supplier<Pose2d> questPose = quest::getQuestPoseRaw;
+		
 		return Commands.repeatingSequence(
 				Commands.run(
 						() -> {
@@ -71,6 +69,7 @@ public class CalibrateQuestCommand {
 									calculatedOffsetToRobot.getY());
 						})
 						.onlyIf(() -> questPose.get().getRotation().getDegrees() > 30))
+				.beforeStarting(Commands.runOnce(() -> initPose = quest.getQuestPoseRaw()))
 				.finallyDo(
 						() -> {
 							// Update current offset

--- a/src/main/java/frc/robot/util/VisionData.java
+++ b/src/main/java/frc/robot/util/VisionData.java
@@ -11,31 +11,8 @@ import edu.wpi.first.math.numbers.N3;
 
 /** Add your docs here. */
 public class VisionData {
-    private Pose2d pose;
-    private double timestamp;
-    private Matrix<N3, N1> stddev;
-
-    public VisionData(Pose2d pose, double timestamp, Matrix<N3, N1> stddev) {
-        this.pose = pose;
-        this.timestamp = timestamp;
-        this.stddev = stddev;
-    }
-
-    public void updateVisionData(Pose2d pose, double timestamp, Matrix<N3, N1> stddev) {
-        this.pose = pose;
-        this.timestamp = timestamp;
-        this.stddev = stddev;
-    }
-
-    public Pose2d getPose() {
-        return pose;
-    }
-
-    public double getDataTimestamp() {
-        return timestamp;
-    }
-
-    public Matrix<N3, N1> getStdMatrix() {
-        return stddev;
+    @FunctionalInterface
+    public static interface EstimateConsumer {
+        public void accept(Pose2d pose, double timestamp, Matrix<N3, N1> estimationStdDevs);
     }
 }

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "photonlib.json",
     "name": "photonlib",
-    "version": "v2025.2.1",
+    "version": "v2025.3.1",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
     "frcYear": "2025",
     "mavenUrls": [
@@ -13,7 +13,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2025.2.1",
+            "version": "v2025.3.1",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -28,7 +28,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-cpp",
-            "version": "v2025.2.1",
+            "version": "v2025.3.1",
             "libName": "photonlib",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -43,7 +43,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2025.2.1",
+            "version": "v2025.3.1",
             "libName": "photontargeting",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -60,12 +60,12 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-java",
-            "version": "v2025.2.1"
+            "version": "v2025.3.1"
         },
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-java",
-            "version": "v2025.2.1"
+            "version": "v2025.3.1"
         }
     ]
 }

--- a/vendordeps/questnavlib-v2025-1.1.0-beta.json
+++ b/vendordeps/questnavlib-v2025-1.1.0-beta.json
@@ -1,19 +1,19 @@
 {
   "fileName": "questnavlib.json",
   "name": "questnavlib",
-  "version": "2025-1.0.1-beta",
+  "version": "2025-1.1.0-beta",
   "uuid": "a706fe68-86e5-4aed-92c5-ce05aca007f0",
   "frcYear": "2025",
   "mavenUrls": [
     "https://maven.questnav.gg/releases",
     "https://maven.questnav.gg/snapshots"
   ],
-  "jsonUrl": "https://maven.questnav.gg/releases/gg/questnav/questnavlib-json/2025-1.0.1-beta/questnavlib-json-2025-1.0.1-beta.json",
+  "jsonUrl": "https://maven.questnav.gg/releases/gg/questnav/questnavlib-json/2025-1.1.0-beta/questnavlib-json-2025-1.1.0-beta.json",
   "javaDependencies": [
     {
       "groupId": "gg.questnav",
       "artifactId": "questnavlib-java",
-      "version": "2025-1.0.1-beta"
+      "version": "2025-1.1.0-beta"
     }
   ],
     "cppDependencies": [],


### PR DESCRIPTION
This PR adds the PhotonVision subsystem for getting the robot's field position, refactors the QuestNav subsystem for better integration with PhotonVision, updates the PV and QN libraries, changes the PathPlanner autonomous routines to not reset the robot's position at the start, tweaks the QN calibration command, and adds logic to set the QN position with the PV data when the robot is enabled.

I would also recommend testing the below change to when the PV data is used. The current code will reset the QN position when both the autonomous and teleoperated period start. During competitions, we want to reset the position only once at the start of the autonomous period, but when we are testing at home, we want to reset the position when the robot is enabled in the teleoperated period to bypass the autonomous requirement. 

<details>
  <summary>Change</summary>

 ```diff
diff --git a/src/main/java/frc/robot/RobotContainer.java b/src/main/java/frc/robot/RobotContainer.java
index 6f922bd..94ae7a7 100644
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -52,8 +52,8 @@ public class RobotContainer {
 	public RobotContainer() {
 		resetOdometry(new Pose2d(1, 1, Rotation2d.kZero));
 
-		// reset the odometry to the pv's inital position
-		new Trigger(RobotState::isEnabled)
+		// reset the odometry to the pv's inital position during teleop only when not at comp
+		new Trigger(RobotState::isTeleop).and(new Trigger(DriverStation::isFMSAttached).negate())
 				.onTrue(autoDriving(Commands.runOnce(() -> resetOdometry(photonVision.getPose()))));
 
 		// Configure commands for PathPlanner.
@@ -253,6 +253,7 @@ public class RobotContainer {
 	}
 
 	public Command getAutonomousCommand() {
-		return autoChooser.getSelected();
+		return autoChooser.getSelected()
+         .beforeStarting(() -> resetOdometry(photonVision.getPose()));
 	}
 }
```
</details>

We could reset the QN position at the start of the teleoperated period at competitions with PV, but we are not sure if the robot will see any tags at the start of the teleoperated period as the robot has moved during the autonomous period. The PV subsystem should have additional checks in it to verify the data from `getPose()` is current and not stale before trying to use the data in the teleoperated period. The current code assumes the data is recent which should be true at the start of the autonomous period. The QN subsystem has checks for current data.