### PR TITLE
Add game piece tracking

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -21,6 +21,7 @@ import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
+import edu.wpi.first.units.measure.Time;
 
 public final class Constants {
 
@@ -75,6 +76,12 @@ public final class Constants {
             Degrees.of(0), // pitch, counterclockwise rotation angle around the y axis
             Degrees.of(0) // yaw, counterclockwise rotation angle around the z axis
         ));
+    /** game piece time to live when it should be in view of the camera */
+    public static final Time IN_VIEW_TTL = Seconds.of(0.5);
+    /** game piece time to live when it should not be in view of the camera */
+    public static final Time OUT_VIEW_TTL = Seconds.of(15.0);
+    /** How much time between loop runs. Defaults to 0.02s (or 50 Hz) */
+    public static final Time LOOP_TIME = Seconds.of(0.02);
   }
 
   public static class PVConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -62,7 +62,7 @@ public final class Constants {
      * not strictly the camera's FOV but rather the camera's fov for game piece
      * tracking capability
      */
-    public static final double CAMERA_FOV = Math.cos(Degrees.of(30).in(Radians));
+    public static final Angle CAMERA_FOV = Degrees.of(30);
     /** Distance from the camera that the camera can track game pieces */
     public static final Distance CAMERA_DEPTH = Feet.of(8);
     /** position of camera on robot */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -51,6 +51,32 @@ public final class Constants {
     );
   }
 
+  public static class GamePieceDetectorConstants {
+    public static final String CAMERA_NAME = "Orange Camera";
+    public static final int FILTER_WINDOW_SIZE = 5;
+    /** height of game piece off the ground when we are tracking it */
+    public static final Distance OBJECT_HEIGHT_Z = Inches.of(2);
+    /** distance to combine multiple position readings into one */
+    public static final Distance CLOSENESS_THREASHOLD = Inches.of(5);
+    /**
+     * not strictly the camera's FOV but rather the camera's fov for game piece
+     * tracking capability
+     */
+    public static final double CAMERA_FOV = Math.cos(Degrees.of(30).in(Radians));
+    /** Distance from the camera that the camera can track game pieces */
+    public static final Distance CAMERA_DEPTH = Feet.of(8);
+    /** position of camera on robot */
+    public static final Transform3d ROBOT_TO_CAMERA = new Transform3d(
+        Inches.of(5), // x, positive forward
+        Inches.of(12.4), // y, positive left
+        Inches.of(21.75), // z, positive up
+        new Rotation3d(
+            Degrees.of(0), // roll, counterclockwise rotation angle around the X axis
+            Degrees.of(0), // pitch, counterclockwise rotation angle around the y axis
+            Degrees.of(0) // yaw, counterclockwise rotation angle around the z axis
+        ));
+  }
+
   public static class PVConstants {
     public static final String CAMERA_NAME = "Yellow Camera";
     // The layout of the AprilTags on the field

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,6 +6,7 @@ import frc.robot.Constants.CoralConstants;
 import frc.robot.Constants.ElevatorConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.AutoDriveToReefCommand;
+import frc.robot.commands.AutoDriveToGamePieceCommand;
 import frc.robot.subsystems.*;
 import frc.robot.util.CalibrateQuestCommand;
 import swervelib.SwerveInputStream;
@@ -36,6 +37,8 @@ public class RobotContainer {
 	private final QuestNavSubsystem questNav = new QuestNavSubsystem(drivebase::addVisionMeasurement);
 	private final PhotonVisionSubsystem photonVision = new PhotonVisionSubsystem(
 			drivebase::addVisionMeasurement, false);
+	private final GamePieceDetector gamePieceDetector = new GamePieceDetector(
+			() -> drivebase.getSwerveDrive().getPose(), drivebase.getSwerveDrive().field);
 
 	private final Elevator elevator = new Elevator();
 	private final Coral coral = new Coral();
@@ -167,6 +170,8 @@ public class RobotContainer {
 
 		m_driverController.x()
 				.onTrue(Commands.runOnce(() -> drivebase.resetOdometry(new Pose2d(3.2, 4.05, Rotation2d.kZero))));
+
+		m_driverController.a().whileTrue(autoDriving(new AutoDriveToGamePieceCommand(gamePieceDetector::getNearestGamePiecePose, drivebase)));
 
 		// m_driverController.povUp().whileTrue(m_Climb.climbCommand());
 		// m_driverController.povDown().whileTrue(m_Climb.reachCommand());

--- a/src/main/java/frc/robot/commands/AutoDriveToGamePieceCommand.java
+++ b/src/main/java/frc/robot/commands/AutoDriveToGamePieceCommand.java
@@ -73,7 +73,7 @@ public class AutoDriveToGamePieceCommand extends Command {
         // or the current robot's position if there isn't any game pices. We do this
         // because it will error out on the closeness check to prevent the command from
         // running if there are no game pieces to drive to
-        Pose2d dest = new Pose2d(goalPoseOptional.orElse(robotPose).getTranslation(), robotPose.getRotation());
+        Pose2d dest = goalPoseOptional.orElse(robotPose);
 
         // the path will error if the drivetrain is too close to the destination
         if (robotPose.getTranslation().getDistance(dest.getTranslation()) < 0.05) {
@@ -88,9 +88,11 @@ public class AutoDriveToGamePieceCommand extends Command {
 
             // only two waypoints for a smooth path: where we are and where we want to go
             waypoints = PathPlannerPath.waypointsFromPoses(robotPose, dest);
-            // we'll set the goal's ending heading to be the same as the robot is currently
-            // to move the robot forward without turning
-            path = new PathPlannerPath(waypoints, constraints, null, new GoalEndState(0.0, robotPose.getRotation()));
+
+            // we'll set the goal's ending heading to be the same as the destination heading.
+            // this will rotate the robot to be facing the game piece as the goal pose's
+            // heaading is the rotation from the current robot position to the game piece
+            path = new PathPlannerPath(waypoints, constraints, null, new GoalEndState(0.0, dest.getRotation()));
             path.preventFlipping = true;
 
             // add to field for visualization

--- a/src/main/java/frc/robot/commands/AutoDriveToGamePieceCommand.java
+++ b/src/main/java/frc/robot/commands/AutoDriveToGamePieceCommand.java
@@ -17,97 +17,105 @@ import com.pathplanner.lib.path.Waypoint;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
-import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.subsystems.SwerveSubsystem;
 
 public class AutoDriveToGamePieceCommand extends Command {
-  private SwerveSubsystem swerveSubsystem;
-  private Supplier<Optional<Pose2d>> goal;
-  private PathConstraints constraints;
-  private List<Waypoint> waypoints;
-  private PathPlannerPath path;
-  private Command followingCommand;
-  private Alert tooCloseAlert;
-  private Alert noObjectAlert;
+    private final SwerveSubsystem swerveSubsystem;
+    private final Supplier<Optional<Pose2d>> goalSupplier;
+    private final PathConstraints constraints;
+    private final Alert tooCloseAlert;
+    private final Alert noGPAlert;
+    private List<Waypoint> waypoints;
+    private PathPlannerPath path;
+    private Command followingCommand;
 
-  /**
-   * Auto drives to the closest reef side location. This class essentially wraps
-   * {@code AutoBuilder.followPath(path)} with a dynamically changing
-   * source/destination.
-   * 
-   * @param goal            the position to drive to. This should be from the
-   *                        blue alliance's AB side in world space coordinates.
-   * @param swerveSubsystem the swerve drive to drive the path
-   */
-  public AutoDriveToGamePieceCommand(Supplier<Optional<Pose2d>> goal, SwerveSubsystem swerveSubsystem) {
-    addRequirements(swerveSubsystem);
-    this.swerveSubsystem = swerveSubsystem;
-    this.goal = goal;
-    constraints = new PathConstraints(2, 1, 1, 1);
-    tooCloseAlert = new Alert("Unable to AutoDrive: Too Close!!", AlertType.kWarning);
-    noObjectAlert = new Alert("Unable to AutoDrive: No Objects Found!!", AlertType.kWarning);
-
-  }
-
-  // Called when the command is initially scheduled.
-  @Override
-  public void initialize() {
-    Pose2d robotPose = swerveSubsystem.getSwerveDrive().getPose();
-    Optional<Pose2d> poseOptional = goal.get();
-    Alert activeAlert;
-
-    if (poseOptional.isEmpty()) {
-      // nothing to drive to
-      activeAlert = noObjectAlert;
-    } else {
-      activeAlert = tooCloseAlert;
+    /**
+     * Auto drives to the closest game piece. This class essentially wraps
+     * {@link AutoBuilder#followPath(PathPlannerPath)} with a dynamically changing
+     * goal based on the nearest game object supplied in {@code goalSupplier}.
+     * <p>
+     * Will alert if the requested pose to drive to is too close or if there are no
+     * valid game pieces to drive to.
+     * 
+     * @param goalSupplier    the position to drive to in worldspace coordinates.
+     *                        Will not drive if the optional supplied
+     *                        {@link Optional#isEmpty()} (assumed to have no valid
+     *                        game pieces to drive to).
+     * @param swerveSubsystem the swerve drive to drive the path
+     */
+    public AutoDriveToGamePieceCommand(Supplier<Optional<Pose2d>> goalSupplier, SwerveSubsystem swerveSubsystem) {
+        addRequirements(swerveSubsystem);
+        this.swerveSubsystem = swerveSubsystem;
+        this.goalSupplier = goalSupplier;
+        constraints = new PathConstraints(2, 1, 1, 1);
+        tooCloseAlert = new Alert("Unable to AutoDrive: Too Close!!", AlertType.kWarning);
+        noGPAlert = new Alert("Unable to AutoDrive: No Game Pieces Found!!", AlertType.kWarning);
     }
-    // this will cause the path to error out below as it'll set the dest to be the
-    // current robot's pose
-    Pose2d dest = goal.get().orElse(robotPose);
 
-    // the path will error if the drivetrain is too close to the destination
-    if (robotPose.getTranslation().getDistance(dest.getTranslation()) < 0.05) {
-      // so just do nothing if the path is too close
-      DataLogManager.log("Unable to AutoDrive: Too Close");
-      activeAlert.set(true);
+    // Called when the command is initially scheduled.
+    @Override
+    public void initialize() {
+        Pose2d robotPose = swerveSubsystem.getSwerveDrive().getPose();
+        Optional<Pose2d> goalPoseOptional = goalSupplier.get();
+        Alert activeAlert;
 
-      // this will infinitly consume the drivetrain, but this command ends once the
-      // user releases the trigger (needed for alert to function)
-      followingCommand = Commands.idle().finallyDo(() -> activeAlert.set(false));
-    } else {
-      swerveSubsystem.getSwerveDrive().field.getObject("Goal").setPose(dest);
+        // change the alert to prioritize no game pieces being found
+        if (goalPoseOptional.isEmpty()) {
+            // nothing to drive to
+            activeAlert = noGPAlert;
+        } else {
+            activeAlert = tooCloseAlert;
+        }
 
-      // only two waypoints for a smooth path: where we are and where we want to go
-      waypoints = PathPlannerPath.waypointsFromPoses(robotPose, dest);
-      path = new PathPlannerPath(waypoints, constraints, null, new GoalEndState(0.0, dest.getRotation()));
-      path.preventFlipping = true;
+        // this will make the goal position either the nearest game piece if one exists
+        // or the current robot's position if there isn't any game pices. We do this
+        // because it will error out on the closeness check to prevent the command from
+        // running if there are no game pieces to drive to
+        Pose2d dest = new Pose2d(goalPoseOptional.orElse(robotPose).getTranslation(), robotPose.getRotation());
 
-      // add to field for visualization
-      swerveSubsystem.getSwerveDrive().field.getObject("traj").setPoses(path.getPathPoses());
+        // the path will error if the drivetrain is too close to the destination
+        if (robotPose.getTranslation().getDistance(dest.getTranslation()) < 0.05) {
+            // so just do nothing if the path is too close
+            activeAlert.set(true);
 
-      followingCommand = AutoBuilder.followPath(path);
+            // this will infinitly consume the drivetrain, but this command ends once the
+            // user releases the trigger (needed for alert to function)
+            followingCommand = Commands.idle().finallyDo(() -> activeAlert.set(false));
+        } else {
+            swerveSubsystem.getSwerveDrive().field.getObject("GoalGP").setPose(dest);
+
+            // only two waypoints for a smooth path: where we are and where we want to go
+            waypoints = PathPlannerPath.waypointsFromPoses(robotPose, dest);
+            // we'll set the goal's ending heading to be the same as the robot is currently
+            // to move the robot forward without turning
+            path = new PathPlannerPath(waypoints, constraints, null, new GoalEndState(0.0, robotPose.getRotation()));
+            path.preventFlipping = true;
+
+            // add to field for visualization
+            swerveSubsystem.getSwerveDrive().field.getObject("trajGP").setPoses(path.getPathPoses());
+
+            followingCommand = AutoBuilder.followPath(path);
+        }
+        followingCommand.initialize();
     }
-    followingCommand.initialize();
-  }
 
-  // Called every time the scheduler runs while the command is scheduled.
-  @Override
-  public void execute() {
-    followingCommand.execute();
-  }
+    // Called every time the scheduler runs while the command is scheduled.
+    @Override
+    public void execute() {
+        followingCommand.execute();
+    }
 
-  // Called once the command ends or is interrupted.
-  @Override
-  public void end(boolean interrupted) {
-    followingCommand.end(interrupted);
-  }
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted) {
+        followingCommand.end(interrupted);
+    }
 
-  // Returns true when the command should end.
-  @Override
-  public boolean isFinished() {
-    return followingCommand.isFinished();
-  }
+    // Returns true when the command should end.
+    @Override
+    public boolean isFinished() {
+        return followingCommand.isFinished();
+    }
 }

--- a/src/main/java/frc/robot/commands/AutoDriveToGamePieceCommand.java
+++ b/src/main/java/frc/robot/commands/AutoDriveToGamePieceCommand.java
@@ -1,0 +1,113 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import com.pathplanner.lib.auto.AutoBuilder;
+import com.pathplanner.lib.path.GoalEndState;
+import com.pathplanner.lib.path.PathConstraints;
+import com.pathplanner.lib.path.PathPlannerPath;
+import com.pathplanner.lib.path.Waypoint;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj.Alert.AlertType;
+import edu.wpi.first.wpilibj.DataLogManager;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystems.SwerveSubsystem;
+
+public class AutoDriveToGamePieceCommand extends Command {
+  private SwerveSubsystem swerveSubsystem;
+  private Supplier<Optional<Pose2d>> goal;
+  private PathConstraints constraints;
+  private List<Waypoint> waypoints;
+  private PathPlannerPath path;
+  private Command followingCommand;
+  private Alert tooCloseAlert;
+  private Alert noObjectAlert;
+
+  /**
+   * Auto drives to the closest reef side location. This class essentially wraps
+   * {@code AutoBuilder.followPath(path)} with a dynamically changing
+   * source/destination.
+   * 
+   * @param goal            the position to drive to. This should be from the
+   *                        blue alliance's AB side in world space coordinates.
+   * @param swerveSubsystem the swerve drive to drive the path
+   */
+  public AutoDriveToGamePieceCommand(Supplier<Optional<Pose2d>> goal, SwerveSubsystem swerveSubsystem) {
+    addRequirements(swerveSubsystem);
+    this.swerveSubsystem = swerveSubsystem;
+    this.goal = goal;
+    constraints = new PathConstraints(2, 1, 1, 1);
+    tooCloseAlert = new Alert("Unable to AutoDrive: Too Close!!", AlertType.kWarning);
+    noObjectAlert = new Alert("Unable to AutoDrive: No Objects Found!!", AlertType.kWarning);
+
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    Pose2d robotPose = swerveSubsystem.getSwerveDrive().getPose();
+    Optional<Pose2d> poseOptional = goal.get();
+    Alert activeAlert;
+
+    if (poseOptional.isEmpty()) {
+      // nothing to drive to
+      activeAlert = noObjectAlert;
+    } else {
+      activeAlert = tooCloseAlert;
+    }
+    // this will cause the path to error out below as it'll set the dest to be the
+    // current robot's pose
+    Pose2d dest = goal.get().orElse(robotPose);
+
+    // the path will error if the drivetrain is too close to the destination
+    if (robotPose.getTranslation().getDistance(dest.getTranslation()) < 0.05) {
+      // so just do nothing if the path is too close
+      DataLogManager.log("Unable to AutoDrive: Too Close");
+      activeAlert.set(true);
+
+      // this will infinitly consume the drivetrain, but this command ends once the
+      // user releases the trigger (needed for alert to function)
+      followingCommand = Commands.idle().finallyDo(() -> activeAlert.set(false));
+    } else {
+      swerveSubsystem.getSwerveDrive().field.getObject("Goal").setPose(dest);
+
+      // only two waypoints for a smooth path: where we are and where we want to go
+      waypoints = PathPlannerPath.waypointsFromPoses(robotPose, dest);
+      path = new PathPlannerPath(waypoints, constraints, null, new GoalEndState(0.0, dest.getRotation()));
+      path.preventFlipping = true;
+
+      // add to field for visualization
+      swerveSubsystem.getSwerveDrive().field.getObject("traj").setPoses(path.getPathPoses());
+
+      followingCommand = AutoBuilder.followPath(path);
+    }
+    followingCommand.initialize();
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    followingCommand.execute();
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    followingCommand.end(interrupted);
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return followingCommand.isFinished();
+  }
+}

--- a/src/main/java/frc/robot/subsystems/GamePieceDetector.java
+++ b/src/main/java/frc/robot/subsystems/GamePieceDetector.java
@@ -46,11 +46,11 @@ public class GamePieceDetector extends SubsystemBase {
 
 	/**
 	 * Gets the nearest game piece to the robot. The object's rotation
-	 * value has no real meaning here, but {@link Pose2d}s are easier to work with
-	 * later.
+	 * value represents the directon from the robot's position to the nearest game
+	 * piece.
 	 * 
 	 * @return either the nearest tracked game piece's {@link Pose2d} or
-	 *         {@code Optional.Empty} if the robot has not seen any game pieces.
+	 *         {@link Optional#empty()} if the robot has not seen any game pieces.
 	 */
 	public Optional<Pose2d> getNearestGamePiecePose() {
 		return trackedGamePieceManager.getNearestGamePiecePose(robotPoseSupplier.get());

--- a/src/main/java/frc/robot/subsystems/GamePieceDetector.java
+++ b/src/main/java/frc/robot/subsystems/GamePieceDetector.java
@@ -1,0 +1,91 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import static edu.wpi.first.units.Units.Meters;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.photonvision.PhotonCamera;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.GamePieceDetectorConstants;
+import frc.robot.util.objtrack.TrackedGamePieceManager;
+
+public class GamePieceDetector extends SubsystemBase {
+	private final PhotonCamera camera;
+	private final TrackedGamePieceManager trackedGamePieceManager;
+	private final Supplier<Pose2d> robotPoseSupplier;
+	private final Field2d field;
+	private final Transform2d camTransform = new Transform2d(GamePieceDetectorConstants.ROBOT_TO_CAMERA.getX(),
+			GamePieceDetectorConstants.ROBOT_TO_CAMERA.getY(),
+			GamePieceDetectorConstants.ROBOT_TO_CAMERA.getRotation().toRotation2d());
+
+	/**
+	 * Stores a history of seen game pieces and lets you get the nearest one's
+	 * position with {@link #getNearestGamePiecePose()}.
+	 * 
+	 * @param robotPoseSupplier a supplier to get the current robot's world position
+	 * @param field             a field to add tracked game pieces onto for
+	 *                          visualization purposes
+	 */
+	public GamePieceDetector(Supplier<Pose2d> robotPoseSupplier, Field2d field) {
+		this.robotPoseSupplier = robotPoseSupplier;
+		this.field = field;
+		camera = new PhotonCamera(GamePieceDetectorConstants.CAMERA_NAME);
+		trackedGamePieceManager = new TrackedGamePieceManager();
+
+	}
+
+	/**
+	 * Gets the nearest game piece to the robot. The object's rotation
+	 * value has no real meaning here, but {@link Pose2d}s are easier to work with
+	 * later.
+	 * 
+	 * @return either the nearest tracked game piece's {@link Pose2d} or
+	 *         {@code Optional.Empty} if the robot has not seen any game pieces.
+	 */
+	public Optional<Pose2d> getNearestGamePiecePose() {
+		return trackedGamePieceManager.getNearestGamePiecePose(robotPoseSupplier.get());
+	}
+
+	// This method will be called once per scheduler run
+	@Override
+	public void periodic() {
+		// first add any new game pieces to the mamanger
+		for (var result : camera.getAllUnreadResults()) {
+			for (var target : result.getTargets()) {
+				// convert camera pitch and yaw to x and y coordinates relative to the camera
+				// through spherical to Cartesian coordinate transformations
+				double r = GamePieceDetectorConstants.OBJECT_HEIGHT_Z.in(Meters) / Math.cos(target.getYaw());
+				double theta = target.getYaw() + GamePieceDetectorConstants.ROBOT_TO_CAMERA.getRotation().getZ();
+				double rho = target.getPitch() + GamePieceDetectorConstants.ROBOT_TO_CAMERA.getRotation().getY();
+				double x = r * Math.sin(theta) * Math.cos(rho);
+				double y = r * Math.sin(theta) * Math.sin(rho);
+
+				// the rotation value is irrelavent here
+				Pose2d targ = new Pose2d(x, y, Rotation2d.kZero);
+
+				// coordinate transformation: camera to robot
+				targ = targ.transformBy(camTransform.inverse());
+
+				// coordinate transformation: robot to world (not 100% sure this is needed)
+				targ = targ.relativeTo(robotPoseSupplier.get());
+
+				// add to manager
+				trackedGamePieceManager.addTrackedGamePiece(targ.getTranslation());
+			}
+		}
+
+		// then update the manager
+		trackedGamePieceManager.updateTTL(robotPoseSupplier.get());
+		trackedGamePieceManager.updateField(field);
+	}
+}

--- a/src/main/java/frc/robot/subsystems/GamePieceDetector.java
+++ b/src/main/java/frc/robot/subsystems/GamePieceDetector.java
@@ -14,6 +14,7 @@ import org.photonvision.PhotonCamera;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.GamePieceDetectorConstants;
@@ -65,8 +66,10 @@ public class GamePieceDetector extends SubsystemBase {
 				// convert camera pitch and yaw to x and y coordinates relative to the camera
 				// through spherical to Cartesian coordinate transformations
 				double r = GamePieceDetectorConstants.OBJECT_HEIGHT_Z.in(Meters) / Math.cos(target.getYaw());
-				double theta = target.getYaw() + GamePieceDetectorConstants.ROBOT_TO_CAMERA.getRotation().getZ();
-				double rho = target.getPitch() + GamePieceDetectorConstants.ROBOT_TO_CAMERA.getRotation().getY();
+				double theta = Units.degreesToRadians(target.getYaw())
+						+ GamePieceDetectorConstants.ROBOT_TO_CAMERA.getRotation().getZ();
+				double rho = Units.degreesToRadians(target.getPitch())
+						+ GamePieceDetectorConstants.ROBOT_TO_CAMERA.getRotation().getY();
 				double x = r * Math.sin(theta) * Math.cos(rho);
 				double y = r * Math.sin(theta) * Math.sin(rho);
 

--- a/src/main/java/frc/robot/subsystems/GamePieceDetector.java
+++ b/src/main/java/frc/robot/subsystems/GamePieceDetector.java
@@ -27,8 +27,7 @@ public class GamePieceDetector extends SubsystemBase {
 	private final Supplier<Pose2d> robotPoseSupplier;
 	private final Field2d field;
 	private final Transform2d robotToCameraTransform = new Transform2d(
-			GamePieceDetectorConstants.ROBOT_TO_CAMERA.getX(),
-			GamePieceDetectorConstants.ROBOT_TO_CAMERA.getY(),
+			GamePieceDetectorConstants.ROBOT_TO_CAMERA.getTranslation().toTranslation2d(),
 			GamePieceDetectorConstants.ROBOT_TO_CAMERA.getRotation().toRotation2d());
 
 	/**
@@ -44,7 +43,6 @@ public class GamePieceDetector extends SubsystemBase {
 		this.field = field;
 		camera = new PhotonCamera(GamePieceDetectorConstants.CAMERA_NAME);
 		trackedGamePieceManager = new TrackedGamePieceManager();
-
 	}
 
 	/**

--- a/src/main/java/frc/robot/util/objtrack/TrackedGamePiece.java
+++ b/src/main/java/frc/robot/util/objtrack/TrackedGamePiece.java
@@ -1,0 +1,124 @@
+package frc.robot.util.objtrack;
+
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.Seconds;
+
+import edu.wpi.first.math.filter.MedianFilter;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.units.measure.MutTime;
+import frc.robot.Constants.GamePieceDetectorConstants;
+
+public class TrackedGamePiece {
+    private final MedianFilter x;
+    private final MedianFilter y;
+    private final int UUID;
+    private final MutTime TTL = Seconds.mutable(0);
+    private boolean visibleLatch;
+
+    /**
+     * Creates a new game piece to be tracked. Position can be updated with new data
+     * via {@link #addIfNear(Translation2d)}. Time to live can be updated through
+     * {@link #updateTTL(Pose2d)}.
+     * 
+     * @param tx   Position of the game piece in the world.
+     * @param UUID unique id for the game piece
+     */
+    public TrackedGamePiece(Translation2d tx, int UUID) {
+        this.UUID = UUID;
+        x = new MedianFilter(GamePieceDetectorConstants.FILTER_WINDOW_SIZE);
+        y = new MedianFilter(GamePieceDetectorConstants.FILTER_WINDOW_SIZE);
+        TTL.mut_replace(Seconds.of(0.5));
+        visibleLatch = false;
+
+        x.calculate(tx.getX());
+        y.calculate(tx.getY());
+    }
+
+    /**
+     * @return this game piece's unique ID
+     */
+    public int getUUID() {
+        return UUID;
+    }
+
+    /**
+     * Checks whether the input translation is near this current game piece. If it
+     * is, then it'll add to the current game piece and return {@code true}.
+     * 
+     * @param tx position of new game piece location
+     * @return {@code true} if the input translation was near a currently existing
+     *         point
+     */
+    public boolean addIfNear(Translation2d tx) {
+        double xx = x.lastValue() - tx.getX();
+        double yy = y.lastValue() - tx.getY();
+        double distance = Math.sqrt(xx * xx + yy * yy);
+        if (distance < GamePieceDetectorConstants.CLOSENESS_THREASHOLD.in(Meters)) {
+            x.calculate(tx.getX());
+            y.calculate(tx.getY());
+            TTL.mut_replace(Seconds.of(0.5));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Gets the translation of this tracked game piece on the field.
+     * 
+     * @return position of tracked game piece on the field.
+     */
+    public Translation2d getTranslation2d() {
+        return new Translation2d(x.lastValue(), y.lastValue());
+    }
+
+    /**
+     * Updates this tracked game piece's time to live property.
+     * 
+     * @param robot the current position of the robot in world space. Used to
+     *              determine whether this tracked game piece should be in the
+     *              camera's FOV to determine TTL.
+     * @return {@code true} if this tracked game piece must be removed,
+     *         {@code false} if the tracked game piece is still valid.
+     */
+    public boolean updateTTL(Pose2d robot) {
+        // first calculate the view vector from the game piece to the robot
+        Translation2d currTranslation = robot.getTranslation();
+        Translation2d objPositionWS = getTranslation2d();
+
+        // this is the same math used to calculate the angle around the reef
+        currTranslation = currTranslation.minus(objPositionWS);
+        currTranslation = currTranslation.rotateBy(Rotation2d.fromRadians(-0.5));
+
+        Rotation2d angle = Rotation2d.fromRadians(Math.atan2(currTranslation.getY(), currTranslation.getX()));
+
+        Translation2d objToRoboVec = new Translation2d(1, 0).rotateBy(angle);
+
+        // next calculate the robot's view direction vector
+        Translation2d robotViewDir = new Translation2d(1, 0).rotateBy(robot.getRotation());
+
+        boolean visible = robotViewDir.toVector().dot(objToRoboVec.toVector()) < GamePieceDetectorConstants.CAMERA_FOV
+                && currTranslation.getDistance(objPositionWS) < GamePieceDetectorConstants.CAMERA_DEPTH.in(Meters);
+
+        // set TTL to 0.5s when in view for the first time
+        if (visible && visibleLatch) {
+            TTL.mut_replace(Seconds.of(0.5));
+
+            visibleLatch = false;
+        } else if (!visible && !visibleLatch) { // set TTL to 15s when out of view
+
+            TTL.mut_replace(Seconds.of(15));
+            visibleLatch = true;
+        }
+
+        // loop time should be 0.02s
+        TTL.mut_minus(Seconds.of(0.02));
+        if (TTL.in(Seconds) < 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/frc/robot/util/objtrack/TrackedGamePieceManager.java
+++ b/src/main/java/frc/robot/util/objtrack/TrackedGamePieceManager.java
@@ -70,6 +70,12 @@ public class TrackedGamePieceManager {
             return Optional.empty();
         }
 
+        /**
+         * Uses `Pose2d.nearest(List<Pose2d>)` to filter for the nearest position. We
+         * map the internal `List<TrackedGamePiece>` to `List<Pose2d>` by using the game
+         * piece's `Translation2d` and calculating a new `Rotation2d` value from the
+         * angle between the input pose to the game piece.
+         */
         return Optional.of(
                 pose.nearest(trackedGamePieces.stream().map(tgp -> new Pose2d(tgp.getTranslation2d(),
                         tgp.getTranslation2d().minus(pose.getTranslation()).getAngle())).toList()));

--- a/src/main/java/frc/robot/util/objtrack/TrackedGamePieceManager.java
+++ b/src/main/java/frc/robot/util/objtrack/TrackedGamePieceManager.java
@@ -1,0 +1,98 @@
+package frc.robot.util.objtrack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+
+public class TrackedGamePieceManager {
+    private final List<TrackedGamePiece> trackedGamePieces;
+    private int uuidCount;
+
+    /**
+     * A manager to remember seen game pieces on the field.
+     */
+    public TrackedGamePieceManager() {
+        trackedGamePieces = new ArrayList<>();
+        uuidCount = 0;
+    }
+
+    /**
+     * Adds or updates a game piece. If the new game piece is near an already
+     * existing tracked game piece, it will update the position of the already
+     * tracked game piece.
+     * 
+     * @param tx game piece to add
+     */
+    public void addTrackedGamePiece(Translation2d tx) {
+        // check if it is empty, if it is then bypass checking the list entirely
+        if (!trackedGamePieces.isEmpty()) {
+            for (var trackedGamePiece : trackedGamePieces) {
+                if (trackedGamePiece.addIfNear(tx)) {
+                    // when the add is successfull, we are done here
+                    return;
+                }
+            }
+        }
+        trackedGamePieces.add(new TrackedGamePiece(tx, uuidCount++));
+    }
+
+    /**
+     * Updates each tracked game piece's time to live. This is done to ensure any
+     * erroneously tracked game piece will expire and not be remembered. The time to
+     * live is 0.5s for any game piece in the field of view of the camera and 15s
+     * for any game piece not in the field of view of the camera.
+     * 
+     * @param pose the robot's current world space position on the field. Required
+     *             to calculate whether the tracked game piece is in the camera's
+     *             FOV.
+     */
+    public void updateTTL(Pose2d pose) {
+        trackedGamePieces.removeIf(tgp -> tgp.updateTTL(pose));
+    }
+
+    /**
+     * Gets the nearest game piece to the supplied pose. Rotation value is hardcoded
+     * to zero.
+     * 
+     * @param pose pose to get the nearest game piece from, probably the robot's
+     *             current position.
+     * @return {@code Optional.of(Pose2d)} if the robot has a tracked game
+     *         piece or {@code Optional.none } if the robot has no tracked game
+     *         pieces.
+     */
+    public Optional<Pose2d> getNearestGamePiecePose(Pose2d pose) {
+        if (trackedGamePieces.isEmpty()) {
+            return Optional.empty();
+        }
+
+        TrackedGamePiece out = null; // this will be set to something in the loop
+        double minDist = Double.MAX_VALUE;
+        for (var trackedGamePiece : trackedGamePieces) {
+            double dist = trackedGamePiece.getTranslation2d().getDistance(pose.getTranslation());
+            if (dist < minDist) {
+                minDist = dist;
+                out = trackedGamePiece;
+            }
+        }
+
+        return Optional.of(new Pose2d(out.getTranslation2d(), Rotation2d.kZero));
+    }
+
+    /**
+     * Updates the field with all the currently tracked game pieces. Primarily used
+     * for debug but could be used as a driver aid.
+     * 
+     * @param field the field to populate objects onto
+     */
+    public void updateField(Field2d field) {
+        trackedGamePieces.forEach(
+                tgp -> field.getObject("Game Piece " + tgp.getUUID())
+                        .setPose(new Pose2d(tgp.getTranslation2d(), Rotation2d.kZero)));
+    }
+
+}


### PR DESCRIPTION
# Summary
This allows the robot to keep track of game pieces on the floor. The tracked game pieces are put onto the robot's `Field2d` widget for visualization purposes to see game pieces on the ground on the field.  This PR also implements a command to drive to the nearest game piece to the robot.

# Specific notes
## Game piece pose estimation
This uses PhotonVision's object tracking or color filtering to track an object and give a [yaw and pitch value](https://docs.photonvision.org/en/latest/docs/programming/photonlib/getting-target-data.html#getting-data-from-a-target). The PV pitch value is used along with the camera's mounting pitch, mounting height, and the object height to calculate a distance from the camera to the game piece on the floor according to [this algorithm](https://docs.limelightvision.io/docs/docs-limelight/tutorials/tutorial-estimating-distance).

The distance value is then used with the yaw value to compute the position relative to the camera. That relative position is then used along with the relative position from the center of the robot to the camera and the robot's position on the field to calculate the position of the game piece on the field.

## `TrackedGamePiece` specific notes
Each game piece has an x and y position on the field along with a rotation value. This rotation value is only used for visualizing whether the camera should see the game piece (up if in view, down if not in view). The visibility is used to update the time to live for the game piece.

The time to live value is used to automatically clean up any game pieces that are no longer valid. This also removes potential bad readings from lingering. It is reset to a small value when in view and is updated to the same small value when a new position reading updates the game piece's position. It is reset to a larger value when no longer in the camera's view. 

## `AutoDriveToGamePieceCommand` specific notes
This command uses the position of the nearest game piece on the field to create a path and then follows that path. The nearest game piece is queried only once at command initialization. The robot's heading once at the game piece will face towards the game piece from the robot's initial position. For example, if the robot is to the right of the game piece while facing up, the robot will move to the left while rotating to face the left. 

Future improvements may include continually fetching the nearest game piece and using [PathPlanner's pathfinding](https://pathplanner.dev/pplib-pathfinding.html) rather than a simple path.