### PR TITLE
Improve PhotoVision handling

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -25,6 +25,9 @@ import edu.wpi.first.units.measure.Time;
 
 public final class Constants {
 
+  /** How much time between loop runs. Defaults to 0.02s (or 50 Hz) */
+  public static final Time LOOP_TIME = Seconds.of(0.02);
+
   /**
    * Represents the three subsystem states for a desired robot state. Has static
    * subsystem states for predetermined robot configuration.
@@ -110,8 +113,6 @@ public final class Constants {
     public static final Time IN_VIEW_TTL = Seconds.of(0.5);
     /** game piece time to live when it should not be in view of the camera */
     public static final Time OUT_VIEW_TTL = Seconds.of(15.0);
-    /** How much time between loop runs. Defaults to 0.02s (or 50 Hz) */
-    public static final Time LOOP_TIME = Seconds.of(0.02);
   }
 
   public static class PVConstants {
@@ -128,6 +129,8 @@ public final class Constants {
             Degrees.of(0), // pitch, counterclockwise rotation angle around the y axis
             Degrees.of(0) // yaw, counterclockwise rotation angle around the z axis
         ));
+    /** time for the reading to be valid for */
+    public static final Time VALID_TIME = Seconds.of(1.0);
 
     // The standard deviations of our vision estimated poses, which affect
     // correction rate

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -5,6 +5,7 @@ import com.pathplanner.lib.pathfinding.LocalADStar;
 import com.pathplanner.lib.pathfinding.Pathfinding;
 
 import edu.wpi.first.wpilibj.DataLogManager;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
 
 import edu.wpi.first.wpilibj2.command.Command;
@@ -22,6 +23,7 @@ public class Robot extends TimedRobot {
 	public void robotInit() {
 
 		DataLogManager.start();
+		DriverStation.startDataLog(DataLogManager.getLog());
 
 		Pathfinding.setPathfinder(new LocalADStar());
 		FollowPathCommand.warmupCommand().schedule();

--- a/src/main/java/frc/robot/util/objtrack/TrackedGamePiece.java
+++ b/src/main/java/frc/robot/util/objtrack/TrackedGamePiece.java
@@ -9,6 +9,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.units.measure.MutTime;
+import frc.robot.Constants;
 import frc.robot.Constants.GamePieceDetectorConstants;
 
 public class TrackedGamePiece {
@@ -139,7 +140,7 @@ public class TrackedGamePiece {
         }
 
         // subtract by loop time
-        TTL.mut_minus(GamePieceDetectorConstants.LOOP_TIME);
+        TTL.mut_minus(Constants.LOOP_TIME);
 
         // returns true if the time has expired (TTL less than zero)
         return TTL.lt(Seconds.zero());


### PR DESCRIPTION
* Improves setting the robot's position with PhotonVision by better handling not being able to see a tag (also sends an [alert](https://frc-elastic.gitbook.io/docs/additional-features-and-references/widgets-list-and-properties-reference#alerts) to the dashboard if not tracking). 
* Changed to only use the PV pose at the start of the autonomous period (only when at comp). 
* Adds logging for the driverstation reports. 
* Exposes the different possible starting states between auton selected and PV valid being true and false.