### PR TITLE
Add vision system failover and elevator failsafe

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -18,6 +18,7 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
@@ -158,6 +159,8 @@ public final class Constants {
     public static final Distance FLOOR_OFFSET = Inches.of(18.6);
     public static final Distance SPROCKET_PITCH_DIAMETER = Inches.of(1.9);
     public static final Distance CONVERSION_FACTOR = SPROCKET_PITCH_DIAMETER.times(Math.PI * NUM_STAGES / GEAR_RATIO);
+
+    public static final Current MOTOR_CURRENT_LIMIT = Amps.of(40.0);
 
     // control loop parameters
     // feedback constants

--- a/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
@@ -37,7 +37,6 @@ public class PhotonVisionSubsystem extends SubsystemBase {
 	private final PhotonCamera camera;
 	private final PhotonPoseEstimator photonEstimator;
 	private final EstimateConsumer estConsumer;
-	private final boolean useEstConsumer;
 	private final MedianFilter xFilter;
 	private final MedianFilter yFilter;
 	private final MedianFilter thetaFilter;
@@ -51,6 +50,7 @@ public class PhotonVisionSubsystem extends SubsystemBase {
 
 	private Matrix<N3, N1> curStdDevs;
 	private Pose2d lastUpdatedPose;
+	private boolean useEstConsumer;
 
 	/**
 	 * Creates a new PhotonVisionSubsystem.
@@ -81,6 +81,15 @@ public class PhotonVisionSubsystem extends SubsystemBase {
 		photonEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
 
 		lastUpdatedPose = new Pose2d(1, 1, Rotation2d.kZero);
+	}
+
+	/**
+	 * Sets whether the PhotonVision subsystem should be using the estimation
+	 * consumer provided in the constructor. If true, then this will update the
+	 * robot's position based on PhotonVision's pose estimation.
+	 */
+	public void setUseEsimationConsumer(boolean useEstConsumer) {
+		this.useEstConsumer = useEstConsumer;
 	}
 
 	/**

--- a/src/main/java/frc/robot/subsystems/QuestNavSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/QuestNavSubsystem.java
@@ -26,11 +26,30 @@ public class QuestNavSubsystem extends SubsystemBase {
 	private final StructPublisher<Pose2d> worldPosePublisher = NetworkTableInstance.getDefault()
 			.getStructTopic("QuestNav/WorldPose", Pose2d.struct).publish();
 	private Optional<Pose2d> questWorldPose = Optional.empty();
+	private boolean useEstConsumer;
 
 	/** Creates a new QuestNavSubsystem. */
-	public QuestNavSubsystem(EstimateConsumer estimateConsumer) {
+	public QuestNavSubsystem(EstimateConsumer estimateConsumer, boolean useEstConsumer) {
 		this.estConsumer = estimateConsumer;
+		this.useEstConsumer = useEstConsumer;
 		disconnectedAlert = new Alert("QuestNav Not Tracking!!", AlertType.kWarning);
+	}
+
+	/**
+	 * Sets whether the QuestNav subsystem should be using the estimation
+	 * consumer provided in the constructor. If true, then this will update the
+	 * robot's position based on QuestNav's pose estimation.
+	 */
+	public void setUseEstConsumer(boolean useEstConsumer) {
+		this.useEstConsumer = useEstConsumer;
+	}
+
+	/**
+	 * @return whether questnav is currently tracking. Note this is different from
+	 *         being connected.
+	 */
+	public boolean isTracking() {
+		return questNav.isTracking();
 	}
 
 	/**
@@ -131,7 +150,9 @@ public class QuestNavSubsystem extends SubsystemBase {
 				worldPosePublisher.accept(robotPose);
 
 				// Add the measurement to the estimator
-				estConsumer.accept(robotPose, timestamp, QuestConstants.QUESTNAV_STD_DEVS);
+				if (useEstConsumer) {
+					estConsumer.accept(robotPose, timestamp, QuestConstants.QUESTNAV_STD_DEVS);
+				}
 			}
 
 		} else {


### PR DESCRIPTION
This PR adds two things that should hopefully never be needed:
1. A system to automatically switch from updating the robot's position using QuestNav to updating the robot's position using PhotonVision.
2. A system to automatically disable the elevator's control loop if a current threshold is exceeded for too long. 

Both can be reverted to their working state via controls in the dashboard. 

The elevator current debounce time may need to be adjusted to avoid any false positives. This can be done by plotting the motor's current over time during normal operations and setting the debounce time to a value that'll never be exceeded normally.  